### PR TITLE
Fix ambiguous issue_key across projects and add project-scoped issue resolution

### DIFF
--- a/bookbug_db.py
+++ b/bookbug_db.py
@@ -232,8 +232,9 @@ def db_issue_add(conn: sqlite3.Connection, project_id: int,
     except sqlite3.IntegrityError as e:
         return {"ok": False, "error": str(e)}
 
-def db_issue_get(conn: sqlite3.Connection, key_or_id: str):
+def db_issue_get(conn: sqlite3.Connection, key_or_id: str, project_slug: str = ""):
     """issue_key(정수 문자열) 또는 내부 id로 이슈 조회.
+    project_slug를 주면 해당 프로젝트 범위에서만 조회하며,
     크로스 프로젝트 형식 '{slug}#{N}'도 지원."""
     # slug#N 형식 처리
     if "#" in str(key_or_id):
@@ -245,18 +246,29 @@ def db_issue_get(conn: sqlite3.Connection, key_or_id: str):
             (slug, num)
         ).fetchone()
         return row
+    if project_slug:
+        row = conn.execute(
+            "SELECT i.* FROM issues i JOIN projects p ON i.project_id=p.id "
+            "WHERE p.slug=? AND i.issue_key=? AND i.deleted_at IS NULL AND p.deleted_at IS NULL",
+            (project_slug, str(key_or_id))
+        ).fetchone()
+        return row
+
     # 순수 정수 문자열 → issue_key로 먼저 조회
-    row = conn.execute(
-        "SELECT * FROM issues WHERE issue_key=? AND deleted_at IS NULL", (str(key_or_id),)
-    ).fetchone()
-    if not row:
-        try:
-            row = conn.execute(
-                "SELECT * FROM issues WHERE id=? AND deleted_at IS NULL", (int(key_or_id),)
-            ).fetchone()
-        except ValueError:
-            pass
-    return row
+    rows = conn.execute(
+        "SELECT * FROM issues WHERE issue_key=? AND deleted_at IS NULL ORDER BY id", (str(key_or_id),)
+    ).fetchall()
+    if len(rows) == 1:
+        return rows[0]
+    if len(rows) > 1:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT * FROM issues WHERE id=? AND deleted_at IS NULL", (int(key_or_id),)
+        ).fetchone()
+        return row
+    except ValueError:
+        return None
 
 def db_issue_list(conn: sqlite3.Connection, project_id: int,
                   status: str = "", chapter: str = "", category: str = "",

--- a/bookbug_mcp.py
+++ b/bookbug_mcp.py
@@ -35,6 +35,38 @@ mcp = FastMCP(
     instructions="출판 원고 교정용 이슈 트래커",
 )
 
+
+def _resolve_issue(conn, issue: str, project: str = ""):
+    """issue 참조를 안전하게 해석한다. 프로젝트 간 키 충돌을 감지한다."""
+    if project:
+        p = db_project_get(conn, project)
+        if not p:
+            return None, {"ok": False, "error": f"프로젝트 '{project}'를 찾을 수 없습니다"}
+        row = db_issue_get(conn, issue, project_slug=project)
+        if not row:
+            return None, {"ok": False, "error": f"프로젝트 '{project}'에서 이슈 '{issue}'를 찾을 수 없습니다"}
+        return row, None
+
+    row = db_issue_get(conn, issue)
+    if row:
+        return row, None
+
+    if "#" not in str(issue):
+        conflict = conn.execute(
+            "SELECT COUNT(*) FROM issues WHERE issue_key=? AND deleted_at IS NULL",
+            (str(issue),)
+        ).fetchone()[0]
+        if conflict > 1:
+            return None, {
+                "ok": False,
+                "error": (
+                    f"이슈 키 '{issue}'가 여러 프로젝트에 존재합니다. "
+                    "project 파라미터를 지정하거나 'slug#issue_key' 형식을 사용해 주세요"
+                ),
+            }
+
+    return None, {"ok": False, "error": f"이슈 '{issue}'를 찾을 수 없습니다"}
+
 # ─── 프로젝트 관리 ─────────────────────────────────────────────────────────────
 
 @mcp.tool()
@@ -117,18 +149,21 @@ def issue_list(
 
 
 @mcp.tool()
-def issue_show(issue: str) -> dict:
+def issue_show(issue: str, project: str = "") -> dict:
     """이슈의 전체 상세 정보를 반환한다. 태그와 변경 이력 포함."""
     with get_db() as conn:
-        data = db_issue_show(conn, issue)
-    if data is None:
-        return {"ok": False, "error": f"이슈 '{issue}'를 찾을 수 없습니다"}
+        row, err = _resolve_issue(conn, issue, project)
+        if err:
+            return err
+        ref = f"{project}#{row['issue_key']}" if project else issue
+        data = db_issue_show(conn, ref)
     return data
 
 
 @mcp.tool()
 def issue_update(
     issue: str,
+    project: str = "",
     title: Optional[str] = None,
     description: Optional[str] = None,
     status: Optional[str] = None,
@@ -160,20 +195,20 @@ def issue_update(
         return {"ok": False, "error": f"유효하지 않은 심각도: '{updates['severity']}'. 허용값: {', '.join(VALID_SEVERITIES)}"}
 
     with get_db() as conn:
-        row = db_issue_get(conn, issue)
-        if not row:
-            return {"ok": False, "error": f"이슈 '{issue}'를 찾을 수 없습니다"}
+        row, err = _resolve_issue(conn, issue, project)
+        if err:
+            return err
         updated_fields = db_issue_update(conn, row["id"], row, updates, changed_by)
     return {"ok": True, "issue_key": row["issue_key"], "updated_fields": updated_fields}
 
 
 @mcp.tool()
-def issue_resolve(issue: str, resolution: str = "", resolved_by: str = "") -> dict:
+def issue_resolve(issue: str, project: str = "", resolution: str = "", resolved_by: str = "") -> dict:
     """이슈를 resolved 상태로 변경하는 단축 tool."""
     with get_db() as conn:
-        row = db_issue_get(conn, issue)
-        if not row:
-            return {"ok": False, "error": f"이슈 '{issue}'를 찾을 수 없습니다"}
+        row, err = _resolve_issue(conn, issue, project)
+        if err:
+            return err
         updates = {"status": "resolved"}
         if resolution:
             updates["resolution"] = resolution
@@ -263,12 +298,12 @@ def project_stats(project: str) -> dict:
 
 
 @mcp.tool()
-def issue_history(issue: str) -> dict:
+def issue_history(issue: str, project: str = "") -> dict:
     """특정 이슈의 변경 이력을 반환한다."""
     with get_db() as conn:
-        row = db_issue_get(conn, issue)
-        if not row:
-            return {"ok": False, "error": f"이슈 '{issue}'를 찾을 수 없습니다"}
+        row, err = _resolve_issue(conn, issue, project)
+        if err:
+            return err
         history_rows = conn.execute(
             "SELECT * FROM issue_history WHERE issue_id=? ORDER BY changed_at",
             (row["id"],)

--- a/test_bookbug_mcp.py
+++ b/test_bookbug_mcp.py
@@ -180,6 +180,41 @@ class TestIssueTools(unittest.TestCase):
         self.assertFalse(r["ok"])
 
 
+class TestIssueProjectScoping(unittest.TestCase):
+
+    def setUp(self):
+        fresh_db()
+        mcp.project_create("proj-a", "프로젝트 A")
+        mcp.project_create("proj-b", "프로젝트 B")
+        mcp.issue_add("proj-a", "A 이슈 1")
+        mcp.issue_add("proj-b", "B 이슈 1")
+
+    def test_issue_show_ambiguous_without_project(self):
+        r = mcp.issue_show("1")
+        self.assertFalse(r["ok"])
+        self.assertIn("여러 프로젝트", r["error"])
+
+    def test_issue_show_with_project(self):
+        r = mcp.issue_show("1", project="proj-b")
+        self.assertEqual(r["title"], "B 이슈 1")
+
+    def test_issue_update_with_project(self):
+        r = mcp.issue_update("1", project="proj-b", status="in_progress")
+        self.assertTrue(r["ok"])
+        self.assertEqual(mcp.issue_show("1", project="proj-b")["status"], "in_progress")
+        self.assertEqual(mcp.issue_show("1", project="proj-a")["status"], "open")
+
+    def test_issue_resolve_with_project(self):
+        r = mcp.issue_resolve("1", project="proj-a", resolution="A만 해결")
+        self.assertTrue(r["ok"])
+        self.assertEqual(mcp.issue_show("1", project="proj-a")["status"], "resolved")
+        self.assertEqual(mcp.issue_show("1", project="proj-b")["status"], "open")
+
+    def test_slug_key_format_still_supported(self):
+        r = mcp.issue_show("proj-a#1")
+        self.assertEqual(r["title"], "A 이슈 1")
+
+
 class TestBatchUpdate(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
### Motivation

- Prevent accidental lookup/mutation when the same numeric `issue_key` exists in multiple projects by making issue resolution explicit and safe.
- Allow MCP tools to target a specific project when operating on an issue to remove ambiguity and support cross-project workflows.

### Description

- Added a resolver helper ` _resolve_issue` in `bookbug_mcp.py` that detects ambiguous numeric `issue_key` collisions across projects and returns a clear error; it also supports explicit project scoping.
- Extended MCP tools `issue_show`, `issue_update`, `issue_resolve`, and `issue_history` to accept an optional `project` parameter and to use the resolver for safe lookups. 
- Updated DB lookup function `db_issue_get` in `bookbug_db.py` to accept `project_slug` and perform project-bounded lookups, return `None` on ambiguous global matches, and preserve `slug#issue_key` format support. 
- Added regression tests in `test_bookbug_mcp.py` that cover ambiguous-key detection, project-scoped show/update/resolve, and `slug#key` compatibility.

### Testing

- Ran the full unit test suite with `python -m unittest -v`, all tests passed (60 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b16e9bec832aa87eeda9c473f317)