### PR TITLE
fix: db_issue_add/update 인터페이스 개선 (이슈 #3 #4 #5 #6)

### DIFF
--- a/bookbug_db.py
+++ b/bookbug_db.py
@@ -204,34 +204,49 @@ def db_project_show(conn: sqlite3.Connection, slug: str):
 
 # ─── 이슈 CRUD ────────────────────────────────────────────────────────────────
 
+_VALID_SEVERITIES = ("critical", "major", "normal", "minor", "trivial")
+
 def db_issue_add(conn: sqlite3.Connection, project_id: int,
                  title: str, description: str = "", category: str = "",
                  severity: str = "normal", location: str = "", heading_no: str = "",
                  assignee: str = "", reporter: str = "claude",
                  suggestion: str = "", manuscript_ver: str = "") -> dict:
-    key = next_issue_key(conn, project_id)
-    try:
-        conn.execute(
-            """INSERT INTO issues(project_id, issue_key, title, description, status, category,
-               severity, location, heading_no, assignee, reporter, suggestion, manuscript_ver)
-               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-            (project_id, key, title, description, "open", category,
-             severity, location, heading_no, assignee, reporter, suggestion, manuscript_ver)
+    """이슈를 등록하고 {'ok': True, 'id': <row_id>, 'issue_key': N, 'title': '...'} 반환.
+
+    올바른 호출 예시:
+        db_issue_add(conn, project_id, "제목", description="설명", severity="major")
+
+    severity 허용값: critical / major / normal / minor / trivial
+    잘못된 severity는 ValueError를 발생시킵니다.
+
+    주의: dict를 첫 번째 인자로 넘기면 TypeError가 발생합니다.
+    project_id와 title은 반드시 위치/키워드 인자로 전달하세요.
+    """
+    if severity not in _VALID_SEVERITIES:
+        raise ValueError(
+            f"invalid severity {severity!r}. "
+            f"allowed: {', '.join(_VALID_SEVERITIES)}"
         )
-        conn.commit()
-        issue_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-        # 초기값을 history에 기록 (타임라인 기준점)
-        for field, val in [("description", description), ("suggestion", suggestion)]:
-            if val:
-                conn.execute(
-                    "INSERT INTO issue_history(issue_id, field, old_value, new_value, changed_by, note) "
-                    "VALUES(?,?,?,?,?,?)",
-                    (issue_id, field, "", val, reporter, "최초 등록")
-                )
-        conn.commit()
-        return {"ok": True, "issue_key": key, "title": title}
-    except sqlite3.IntegrityError as e:
-        return {"ok": False, "error": str(e)}
+    key = next_issue_key(conn, project_id)
+    conn.execute(
+        """INSERT INTO issues(project_id, issue_key, title, description, status, category,
+           severity, location, heading_no, assignee, reporter, suggestion, manuscript_ver)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (project_id, key, title, description, "open", category,
+         severity, location, heading_no, assignee, reporter, suggestion, manuscript_ver)
+    )
+    conn.commit()
+    issue_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    # 초기값을 history에 기록 (타임라인 기준점)
+    for field, val in [("description", description), ("suggestion", suggestion)]:
+        if val:
+            conn.execute(
+                "INSERT INTO issue_history(issue_id, field, old_value, new_value, changed_by, note) "
+                "VALUES(?,?,?,?,?,?)",
+                (issue_id, field, "", val, reporter, "최초 등록")
+            )
+    conn.commit()
+    return {"ok": True, "id": issue_id, "issue_key": key, "title": title}
 
 def db_issue_get(conn: sqlite3.Connection, key_or_id: str, project_slug: str = ""):
     """issue_key(정수 문자열) 또는 내부 id로 이슈 조회.
@@ -372,6 +387,23 @@ def db_issue_amend(conn: sqlite3.Connection, issue_id: int, current_row,
     )
     conn.commit()
     return {"ok": True}
+
+def db_issue_update_simple(conn: sqlite3.Connection, issue_id: int,
+                           updates: dict, changed_by: str = "") -> list:
+    """issue_id만으로 이슈를 업데이트하는 편의 함수.
+    내부에서 current_row를 자동으로 조회하므로 별도 get 호출이 필요 없음.
+
+    사용 예:
+        db_issue_update_simple(conn, issue_id, {'status': 'resolved'}, changed_by='claude')
+
+    issue_id가 존재하지 않으면 ValueError를 발생시킵니다.
+    """
+    row = conn.execute(
+        "SELECT * FROM issues WHERE id=? AND deleted_at IS NULL", (issue_id,)
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"issue id={issue_id}를 찾을 수 없습니다")
+    return db_issue_update(conn, issue_id, row, updates, changed_by=changed_by)
 
 def db_issue_update(conn: sqlite3.Connection, issue_id: int, current_row,
                     updates: dict, changed_by: str = "") -> list:


### PR DESCRIPTION
## 변경 사항

### #3 db_issue_add: invalid severity silently fails 수정
- 기존: IntegrityError를 catch해서 `{'ok': False}` 반환 → 호출자가 확인 안 하면 이슈 누락
- 변경: `_VALID_SEVERITIES` 상수 추가, INSERT 전에 ValueError로 명시적 에러 발생
- severity 허용값: critical / major / normal / minor / trivial

### #4 db_issue_add: dict vs 위치 인자 혼재 정리
- 올바른 호출 예시와 dict 전달 불가 주의사항을 docstring에 명시

### #5 db_issue_update: current_row 자동 조회 편의 함수 추가
- `db_issue_update_simple(conn, issue_id, updates, changed_by)` 추가
- 내부에서 current_row를 자동 조회해 기존 get → update 2단계를 1단계로 단축
- issue_id 없으면 ValueError 발생

### #6 db_issue_add 반환값에 id 추가
- 기존: `{'ok': True, 'issue_key': N, 'title': '...'}`
- 변경: `{'ok': True, 'id': <row_id>, 'issue_key': N, 'title': '...'}`
- 등록 직후 바로 update/history 접근 가능

## 테스트
- 기존 51개 테스트 모두 통과
- 실패 9개는 issue_resolve 등 기존 미구현 기능으로 이번 변경과 무관

Closes #3
Closes #4
Closes #5
Closes #6