### PR TITLE
fix: add missing `issue_resolve` MCP tool (fixes issues #8, #9)

### DIFF
--- a/bookbug_mcp.py
+++ b/bookbug_mcp.py
@@ -261,6 +261,31 @@ def issue_amend(issue: str, project: str = "", description: str = "", amended_by
     return {"ok": True, "issue_key": row["issue_key"], "amended": True}
 
 
+@mcp.tool()
+def issue_resolve(
+    issue: str,
+    project: str = "",
+    resolution: str = "",
+    resolved_by: str = "",
+) -> dict:
+    """이슈를 resolved 상태로 변경한다. 필요 시 처리 결과(resolution)도 함께 기록한다."""
+    updates = {"status": "resolved"}
+    if resolution:
+        updates["resolution"] = resolution
+
+    with get_db() as conn:
+        row = _resolve_issue(conn, issue, project)
+        updated_fields = db_issue_update(conn, row["id"], row, updates, changed_by=resolved_by)
+        refreshed = db_issue_get(conn, row["id"])
+    return {
+        "ok": True,
+        "issue_key": row["issue_key"],
+        "status": "resolved",
+        "updated_fields": updated_fields,
+        "resolved_at": refreshed["resolved_at"] if refreshed else None,
+    }
+
+
 
 @mcp.tool()
 def issue_delete(issue: str, deleted_by: str = "") -> dict:


### PR DESCRIPTION
### Motivation
- Restore the missing `issue_resolve` MCP tool which caused runtime `AttributeError` and broke issue resolution workflows and tests.

### Description
- Add `issue_resolve` as an `@mcp.tool()` in `bookbug_mcp.py` with parameters `issue`, optional `project`, optional `resolution`, and optional `resolved_by`, which uses `_resolve_issue` and `db_issue_update` to mark an issue `resolved` and record the resolution.

### Testing
- Ran the full test suite with `python -m pytest -q` and all tests passed (`60 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8db72a5b08322b34cf250fb8211a6)