### PR TITLE
Add missing issue_resolve MCP tool

### DIFF
--- a/bookbug_mcp.py
+++ b/bookbug_mcp.py
@@ -247,6 +247,25 @@ def issue_update(
         updated_fields = db_issue_update(conn, row["id"], row, updates, changed_by)
     return {"ok": True, "issue_key": row["issue_key"], "updated_fields": updated_fields}
 
+@mcp.tool()
+def issue_resolve(issue: str, project: str = "", resolution: str = "", resolved_by: str = "") -> dict:
+    """이슈를 resolved 상태로 변경하고 처리 내용을 기록한다."""
+    updates = {"status": "resolved"}
+    if resolution:
+        updates["resolution"] = resolution
+
+    with get_db() as conn:
+        row = _resolve_issue(conn, issue, project)
+        db_issue_update(conn, row["id"], row, updates, changed_by=resolved_by)
+        refreshed = conn.execute("SELECT resolution, resolved_at FROM issues WHERE id=?", (row["id"],)).fetchone()
+
+    return {
+        "ok": True,
+        "issue_key": row["issue_key"],
+        "status": "resolved",
+        "resolution": refreshed["resolution"],
+        "resolved_at": refreshed["resolved_at"],
+    }
 
 @mcp.tool()
 def issue_amend(issue: str, project: str = "", description: str = "", amended_by: str = "") -> dict:


### PR DESCRIPTION
### Motivation
- Fix missing issue resolution API used by several tests that expect an `issue_resolve` MCP tool. 
- Ensure resolving an issue records resolution text, updates status to `resolved`, and exposes `resolved_at` metadata.

### Description
- Implemented `issue_resolve(issue, project="", resolution="", resolved_by="")` as an MCP tool in `bookbug_mcp.py` to set status to `resolved` and optionally store a `resolution` note. 
- Use existing `db_issue_update` to record history and audit fields and then read back `resolution` and `resolved_at` directly from the updated row. 
- Return a consistent response containing `ok`, `issue_key`, `status`, `resolution`, and `resolved_at`.

### Testing
- Ran targeted resolve tests: `pytest -q test_bookbug_mcp.py::TestIssueTools::test_issue_resolve test_bookbug_mcp.py::TestIssueProjectScoping::test_issue_resolve_with_project test_bookbug_mcp.py::TestStatsAndHistory::test_project_stats` and they passed. 
- Ran full test suite with `pytest -q` and observed `60 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc7287ce6c832aad6b6db886f732f2)